### PR TITLE
Add regression test and fix for #40

### DIFF
--- a/tests/acceptance/test_fix_smartquotes.py
+++ b/tests/acceptance/test_fix_smartquotes.py
@@ -66,3 +66,21 @@ Changes were made in these files:
         ^
 """
     )
+
+
+# issue #40 indicates a bug in the way that the fixer behaves on certain
+# non-quote characters
+def test_fix_smartquotes_issue40(runner):
+    result = runner(
+        fix_smartquotes_main,
+        """\
+“foo–bar”
+""",
+    )
+    assert result.exit_code == 1
+    assert (
+        result.file_data
+        == """\
+"foo–bar"
+"""
+    )


### PR DESCRIPTION
The DiffRecorder was setting encoding correctly on read, but not on write. Save the detected encoding and use it in both `open()` calls.

For consistency, the CheckRecorder also follows this pattern.