### PR TITLE
fix: casefold code owner names

### DIFF
--- a/src/texthooks/alphabetize_codeowners.py
+++ b/src/texthooks/alphabetize_codeowners.py
@@ -5,6 +5,7 @@ Alphabetize the list of owners for each path in .github/CODEOWNERS
 Ignores empty lines and comments, but normalizes whitespace on semantically significant
 lines
 """
+
 import sys
 
 from ._common import parse_cli_args
@@ -48,7 +49,7 @@ def sort_line(line: str) -> str:
     path, *owners = line.split()
     if not owners:
         return line
-    return " ".join([path] + sorted(owners, key=str.lower))
+    return " ".join([path] + sorted(owners, key=str.casefold))
 
 
 if __name__ == "__main__":

--- a/tests/acceptance/test_alphabetize_codeowners.py
+++ b/tests/acceptance/test_alphabetize_codeowners.py
@@ -23,6 +23,18 @@ def test_alphabetize_codeowners_sorts(runner):
     assert result.file_data == "/foo/bar.txt @alice @Bob @charlie"
 
 
+def test_alphabetize_codeowners_sorts_other(runner):
+    result = runner(
+        alphabetize_codeowners_main,
+        "/foo/bar.txt @Andy @adam @Bob @alice @charlie @groß @grost @grose",
+    )
+    assert result.exit_code == 1
+    assert (
+        result.file_data
+        == "/foo/bar.txt @adam @alice @Andy @Bob @charlie @grose @groß @grost"
+    )
+
+
 def test_alphabetize_codeowners_ignores_non_semantic_lines(runner):
     result = runner(
         alphabetize_codeowners_main,


### PR DESCRIPTION
Alphabetising of code owner names is not as accurate as it could be as it is using the `str.lower` function.

By changing this to `str.casefold` it more aggressively converts characters to lowercase.  For testing purposes I have used the German letter representing `ss` which is `ß`.