### PR TITLE
feat: add fix-unicode-dashes hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -12,25 +12,25 @@
   types: [text]
 - id: fix-ligatures
   name: Fix ligature characters with NFKD normalization
-  description: "Replace ligature characters with normalized individual characters"
+  description: 'Replace ligature characters with normalized individual characters'
   entry: fix-ligatures
   language: python
   types: [text]
 - id: fix-spaces
   name: 'Normalize irregular space characters to "space"'
-  description: "Replace non-breaking spaces and other characters with the standard space character"
+  description: 'Replace non-breaking spaces and other characters with the standard space character'
   entry: fix-spaces
   language: python
   types: [text]
 - id: forbid-bidi-controls
   name: Forbid the use of unicode BiDi control characters
-  description: "Check for lines of text which contain bidirectional text control characters"
+  description: 'Check for lines of text which contain bidirectional text control characters'
   entry: forbid-bidi-controls
   language: python
   types: [text]
 - id: macro-expand
   name: Expand text macros
-  description: "Perform simple macro replacements in text files"
+  description: 'Perform simple macro replacements in text files'
   entry: macro-expand
   language: python
   types: [text]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,33 +4,39 @@
   entry: fix-smartquotes
   language: python
   types: [text]
+- id: fix-unicode-dashes
+  name: Fix Unicode dash characters
+  description: "Replace Unicode dash characters (en-dash, em-dash, etc.) with ASCII hyphens"
+  entry: fix-unicode-dashes
+  language: python
+  types: [text]
 - id: fix-ligatures
   name: Fix ligature characters with NFKD normalization
-  description: 'Replace ligature characters with normalized individual characters'
+  description: "Replace ligature characters with normalized individual characters"
   entry: fix-ligatures
   language: python
   types: [text]
 - id: fix-spaces
   name: 'Normalize irregular space characters to "space"'
-  description: 'Replace non-breaking spaces and other characters with the standard space character'
+  description: "Replace non-breaking spaces and other characters with the standard space character"
   entry: fix-spaces
   language: python
   types: [text]
 - id: forbid-bidi-controls
   name: Forbid the use of unicode BiDi control characters
-  description: 'Check for lines of text which contain bidirectional text control characters'
+  description: "Check for lines of text which contain bidirectional text control characters"
   entry: forbid-bidi-controls
   language: python
   types: [text]
 - id: macro-expand
   name: Expand text macros
-  description: 'Perform simple macro replacements in text files'
+  description: "Perform simple macro replacements in text files"
   entry: macro-expand
   language: python
   types: [text]
 - id: alphabetize-codeowners
   name: Alphabetize Codeowners
-  description: 'Alphabetize GitHub CODEOWNERS files to list owners in the same order'
+  description: "Alphabetize GitHub CODEOWNERS files to list owners in the same order"
   entry: alphabetize-codeowners
   language: python
   types: [text]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -36,7 +36,7 @@
   types: [text]
 - id: alphabetize-codeowners
   name: Alphabetize Codeowners
-  description: "Alphabetize GitHub CODEOWNERS files to list owners in the same order"
+  description: 'Alphabetize GitHub CODEOWNERS files to list owners in the same order'
   entry: alphabetize-codeowners
   language: python
   types: [text]

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,6 +33,7 @@ console_scripts =
     fix-smartquotes = texthooks.fix_smartquotes:main
     fix-spaces = texthooks.fix_spaces:main
     fix-ligatures = texthooks.fix_ligatures:main
+    fix-unicode-dashes = texthooks.fix_unicode_dashes:main
     forbid-bidi-controls = texthooks.forbid_bidi_controls:main
     macro-expand = texthooks.macro_expand:main
 

--- a/src/texthooks/fix_unicode_dashes.py
+++ b/src/texthooks/fix_unicode_dashes.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 """
 A fixer script which crawls text files and replaces Unicode dash characters
-with ASCII hyphens.
+with ASCII equivalents.
 
 This fixes copy-paste from some applications which replace hyphens with
 Unicode dash characters like en-dash (–), em-dash (—), minus sign (−),
 and fullwidth hyphen (－).
 
-The following Unicode characters are replaced with ASCII hyphens (-):
-- U+2013 EN DASH (–)
-- U+2014 EM DASH (—)
-- U+2212 MINUS SIGN (−)
-- U+FF0D FULLWIDTH HYPHEN-MINUS (－)
+The following Unicode characters are replaced:
+- U+2013 EN DASH (–) → ASCII hyphen (-)
+- U+2014 EM DASH (—) → ASCII double hyphen (--)
+- U+2212 MINUS SIGN (−) → ASCII hyphen (-)
+- U+FF0D FULLWIDTH HYPHEN-MINUS (－) → ASCII hyphen (-)
 
 In files with the offending characters, they are replaced and the run is
 marked as failed. This makes the script suitable as a pre-commit fixer.
@@ -28,26 +28,31 @@ def codepoints2regex(codepoints):
 
 
 # Unicode codepoints for dash characters that should be replaced with ASCII hyphens
-DEFAULT_DASH_CODEPOINTS = (
+DEFAULT_HYPHEN_CODEPOINTS = (
     "2013",  # EN DASH (–)
-    "2014",  # EM DASH (—)
     "2212",  # MINUS SIGN (−)
     "FF0D",  # FULLWIDTH HYPHEN-MINUS (－)
 )
 
+# Unicode codepoints for dash characters that should be replaced with ASCII double hyphens
+DEFAULT_EMDASH_CODEPOINTS = ("2014",)  # EM DASH (—)
 
-def gen_line_fixer(dash_regex):
+
+def gen_line_fixer(hyphen_regex, emdash_regex):
     def line_fixer(line):
-        return dash_regex.sub("-", line)
+        # Replace em-dashes first, then hyphens
+        line = emdash_regex.sub("--", line)
+        line = hyphen_regex.sub("-", line)
+        return line
 
     return line_fixer
 
 
-def do_all_replacements(files, dash_regex, verbosity) -> DiffRecorder:
+def do_all_replacements(files, hyphen_regex, emdash_regex, verbosity) -> DiffRecorder:
     """Do replacements over a set of filenames, and return a list of filenames
     where changes were made."""
     recorder = DiffRecorder(verbosity)
-    line_fixer = gen_line_fixer(dash_regex)
+    line_fixer = gen_line_fixer(hyphen_regex, emdash_regex)
     for fn in all_filenames(files):
         recorder.run_line_fixer(line_fixer, fn)
     return recorder
@@ -55,22 +60,35 @@ def do_all_replacements(files, dash_regex, verbosity) -> DiffRecorder:
 
 def modify_cli_parser(parser):
     parser.add_argument(
-        "--dash-codepoints",
+        "--hyphen-codepoints",
         type=str,
         help=(
             "A comma-delimited list of unicode codepoints for characters "
-            "which should be treated as dashes and replaced with hyphens. "
-            f"default: {','.join(DEFAULT_DASH_CODEPOINTS)}"
+            "which should be treated as hyphens and replaced with single hyphens. "
+            f"default: {','.join(DEFAULT_HYPHEN_CODEPOINTS)}"
+        ),
+    )
+    parser.add_argument(
+        "--emdash-codepoints",
+        type=str,
+        help=(
+            "A comma-delimited list of unicode codepoints for characters "
+            "which should be treated as em-dashes and replaced with double hyphens. "
+            f"default: {','.join(DEFAULT_EMDASH_CODEPOINTS)}"
         ),
     )
 
 
 def postprocess_cli_args(args):
     # convert comma delimited lists manually
-    if args.dash_codepoints:
-        args.dash_codepoints = args.dash_codepoints.split(",")
+    if args.hyphen_codepoints:
+        args.hyphen_codepoints = args.hyphen_codepoints.split(",")
     else:
-        args.dash_codepoints = DEFAULT_DASH_CODEPOINTS
+        args.hyphen_codepoints = DEFAULT_HYPHEN_CODEPOINTS
+    if args.emdash_codepoints:
+        args.emdash_codepoints = args.emdash_codepoints.split(",")
+    else:
+        args.emdash_codepoints = DEFAULT_EMDASH_CODEPOINTS
     return args
 
 
@@ -87,11 +105,13 @@ def parse_args(argv):
 def main(*, argv=None):
     args = parse_args(argv)
 
-    dash_regex = codepoints2regex(args.dash_codepoints)
+    hyphen_regex = codepoints2regex(args.hyphen_codepoints)
+    emdash_regex = codepoints2regex(args.emdash_codepoints)
 
     changes = do_all_replacements(
         all_filenames(args.files),
-        dash_regex,
+        hyphen_regex,
+        emdash_regex,
         args.verbosity,
     )
     if changes:

--- a/src/texthooks/fix_unicode_dashes.py
+++ b/src/texthooks/fix_unicode_dashes.py
@@ -101,4 +101,4 @@ def main(*, argv=None):
 
 
 if __name__ == "__main__":
-    sys.exit(main()) 
+    sys.exit(main())

--- a/src/texthooks/fix_unicode_dashes.py
+++ b/src/texthooks/fix_unicode_dashes.py
@@ -34,7 +34,8 @@ DEFAULT_HYPHEN_CODEPOINTS = (
     "FF0D",  # FULLWIDTH HYPHEN-MINUS (－)
 )
 
-# Unicode codepoints for dash characters that should be replaced with ASCII double hyphens
+# Unicode codepoints for dash characters that should be replaced with
+# ASCII double hyphens
 DEFAULT_EMDASH_CODEPOINTS = ("2014",)  # EM DASH (—)
 
 

--- a/src/texthooks/fix_unicode_dashes.py
+++ b/src/texthooks/fix_unicode_dashes.py
@@ -11,7 +11,14 @@ The following Unicode characters are replaced:
 - U+2013 EN DASH (–) → ASCII hyphen (-)
 - U+2014 EM DASH (—) → ASCII double hyphen (--)
 - U+2212 MINUS SIGN (−) → ASCII hyphen (-)
-- U+FF0D FULLWIDTH HYPHEN-MINUS (－) → ASCII hyphen (-)
+- U+2012 FIGURE DASH (‒) → ASCII hyphen (-)
+- U+02D7 MODIFIER LETTER MINUS SIGN (˗) → ASCII hyphen (-)
+- U+2796 HEAVY MINUS SIGN (➖) → ASCII hyphen (-)
+- U+2010 HYPHEN (‐) → ASCII hyphen (-)
+- U+2011 NON-BREAKING HYPHEN (‑) → ASCII hyphen (-)
+- U+FE63 SMALL HYPHEN-MINUS (﹣) → ASCII hyphen (-)
+- U+FF0D FULLWIDTH HYPHEN-MINUS (－) → ASCII double hyphen (--)
+- U+FE58 SMALL EM DASH (﹘) → ASCII double hyphen (--)
 
 In files with the offending characters, they are replaced and the run is
 marked as failed. This makes the script suitable as a pre-commit fixer.
@@ -31,12 +38,21 @@ def codepoints2regex(codepoints):
 DEFAULT_HYPHEN_CODEPOINTS = (
     "2013",  # EN DASH (–)
     "2212",  # MINUS SIGN (−)
-    "FF0D",  # FULLWIDTH HYPHEN-MINUS (－)
+    "2012",  # FIGURE DASH (‒)
+    "02D7",  # MODIFIER LETTER MINUS SIGN (˗)
+    "2796",  # HEAVY MINUS SIGN (➖)
+    "2010",  # HYPHEN (‐)
+    "2011",  # NON-BREAKING HYPHEN (‑)
+    "FE63",  # SMALL HYPHEN-MINUS (﹣)
 )
 
-# Unicode codepoints for dash characters that should be replaced with
-# ASCII double hyphens
-DEFAULT_EMDASH_CODEPOINTS = ("2014",)  # EM DASH (—)
+# Unicode codepoints for dash characters that should be
+# replaced with ASCII double hyphens
+DEFAULT_EMDASH_CODEPOINTS = (
+    "2014",  # EM DASH (—)
+    "FF0D",  # FULLWIDTH HYPHEN-MINUS (－) - treated as em-dash per reviewer
+    "FE58",  # SMALL EM DASH (﹘)
+)
 
 
 def gen_line_fixer(hyphen_regex, emdash_regex):

--- a/src/texthooks/fix_unicode_dashes.py
+++ b/src/texthooks/fix_unicode_dashes.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""
+A fixer script which crawls text files and replaces Unicode dash characters
+with ASCII hyphens.
+
+This fixes copy-paste from some applications which replace hyphens with
+Unicode dash characters like en-dash (–), em-dash (—), minus sign (−),
+and fullwidth hyphen (－).
+
+The following Unicode characters are replaced with ASCII hyphens (-):
+- U+2013 EN DASH (–)
+- U+2014 EM DASH (—)
+- U+2212 MINUS SIGN (−)
+- U+FF0D FULLWIDTH HYPHEN-MINUS (－)
+
+In files with the offending characters, they are replaced and the run is
+marked as failed. This makes the script suitable as a pre-commit fixer.
+"""
+import re
+import sys
+
+from ._common import all_filenames, codepoints2chars, parse_cli_args
+from ._recorders import DiffRecorder
+
+
+def codepoints2regex(codepoints):
+    return re.compile("(" + "|".join(codepoints2chars(codepoints)) + ")")
+
+
+# Unicode codepoints for dash characters that should be replaced with ASCII hyphens
+DEFAULT_DASH_CODEPOINTS = (
+    "2013",  # EN DASH (–)
+    "2014",  # EM DASH (—)
+    "2212",  # MINUS SIGN (−)
+    "FF0D",  # FULLWIDTH HYPHEN-MINUS (－)
+)
+
+
+def gen_line_fixer(dash_regex):
+    def line_fixer(line):
+        return dash_regex.sub("-", line)
+
+    return line_fixer
+
+
+def do_all_replacements(files, dash_regex, verbosity) -> DiffRecorder:
+    """Do replacements over a set of filenames, and return a list of filenames
+    where changes were made."""
+    recorder = DiffRecorder(verbosity)
+    line_fixer = gen_line_fixer(dash_regex)
+    for fn in all_filenames(files):
+        recorder.run_line_fixer(line_fixer, fn)
+    return recorder
+
+
+def modify_cli_parser(parser):
+    parser.add_argument(
+        "--dash-codepoints",
+        type=str,
+        help=(
+            "A comma-delimited list of unicode codepoints for characters "
+            "which should be treated as dashes and replaced with hyphens. "
+            f"default: {','.join(DEFAULT_DASH_CODEPOINTS)}"
+        ),
+    )
+
+
+def postprocess_cli_args(args):
+    # convert comma delimited lists manually
+    if args.dash_codepoints:
+        args.dash_codepoints = args.dash_codepoints.split(",")
+    else:
+        args.dash_codepoints = DEFAULT_DASH_CODEPOINTS
+    return args
+
+
+def parse_args(argv):
+    return parse_cli_args(
+        __doc__,
+        fixer=True,
+        argv=argv,
+        modify_parser=modify_cli_parser,
+        postprocess=postprocess_cli_args,
+    )
+
+
+def main(*, argv=None):
+    args = parse_args(argv)
+
+    dash_regex = codepoints2regex(args.dash_codepoints)
+
+    changes = do_all_replacements(
+        all_filenames(args.files),
+        dash_regex,
+        args.verbosity,
+    )
+    if changes:
+        changes.print_changes(args.show_changes, args.color)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main()) 

--- a/tests/acceptance/test_fix_unicode_dashes.py
+++ b/tests/acceptance/test_fix_unicode_dashes.py
@@ -1,10 +1,12 @@
 from texthooks._common import strip_ansi
 from texthooks.fix_unicode_dashes import main as fix_unicode_dashes_main
 
+
 def test_fix_unicode_dashes_no_changes(runner):
     result = runner(fix_unicode_dashes_main, "foo-bar")
     assert result.exit_code == 0
     assert result.file_data == "foo-bar"
+
 
 def test_fix_unicode_dashes_en_em_dash(runner):
     result = runner(
@@ -21,6 +23,7 @@ foo-bar-baz
 """
     )
 
+
 def test_fix_unicode_dashes_fullwidth_and_minus(runner):
     # U+FF0D (fullwidth hyphen-minus), U+2212 (minus sign)
     result = runner(
@@ -36,6 +39,7 @@ foo－bar−baz
 foo-bar-baz
 """
     )
+
 
 def test_fix_unicode_dashes_showchanges(runner):
     result = runner(
@@ -63,4 +67,3 @@ Changes were made in these files:
         ^
 """
     )
-

--- a/tests/acceptance/test_fix_unicode_dashes.py
+++ b/tests/acceptance/test_fix_unicode_dashes.py
@@ -1,0 +1,66 @@
+from texthooks._common import strip_ansi
+from texthooks.fix_unicode_dashes import main as fix_unicode_dashes_main
+
+def test_fix_unicode_dashes_no_changes(runner):
+    result = runner(fix_unicode_dashes_main, "foo-bar")
+    assert result.exit_code == 0
+    assert result.file_data == "foo-bar"
+
+def test_fix_unicode_dashes_en_em_dash(runner):
+    result = runner(
+        fix_unicode_dashes_main,
+        """
+foo–bar—baz
+""",
+    )
+    assert result.exit_code == 1
+    assert (
+        result.file_data
+        == """
+foo-bar-baz
+"""
+    )
+
+def test_fix_unicode_dashes_fullwidth_and_minus(runner):
+    # U+FF0D (fullwidth hyphen-minus), U+2212 (minus sign)
+    result = runner(
+        fix_unicode_dashes_main,
+        """
+foo－bar−baz
+""",
+    )
+    assert result.exit_code == 1
+    assert (
+        result.file_data
+        == """
+foo-bar-baz
+"""
+    )
+
+def test_fix_unicode_dashes_showchanges(runner):
+    result = runner(
+        fix_unicode_dashes_main,
+        """
+foo–bar
+""",
+        add_args=["--show-changes"],
+    )
+    assert result.exit_code == 1
+    assert (
+        result.file_data
+        == """
+foo-bar
+"""
+    )
+    assert (
+        strip_ansi(result.stdout)
+        == f"""\
+Changes were made in these files:
+  {result.filename}
+  line 2:
+    -foo–bar
+    +foo-bar
+        ^
+"""
+    )
+

--- a/tests/acceptance/test_fix_unicode_dashes.py
+++ b/tests/acceptance/test_fix_unicode_dashes.py
@@ -19,7 +19,7 @@ foo–bar—baz
     assert (
         result.file_data
         == """
-foo-bar-baz
+foo-bar--baz
 """
     )
 
@@ -65,5 +65,37 @@ Changes were made in these files:
     -foo–bar
     +foo-bar
         ^
+"""
+    )
+
+
+def test_fix_unicode_dashes_emdash_only(runner):
+    result = runner(
+        fix_unicode_dashes_main,
+        """
+foo—bar
+""",
+    )
+    assert result.exit_code == 1
+    assert (
+        result.file_data
+        == """
+foo--bar
+"""
+    )
+
+
+def test_fix_unicode_dashes_mixed_dashes(runner):
+    result = runner(
+        fix_unicode_dashes_main,
+        """
+foo–bar—baz–qux—quux
+""",
+    )
+    assert result.exit_code == 1
+    assert (
+        result.file_data
+        == """
+foo-bar--baz-qux--quux
 """
     )

--- a/tests/acceptance/test_fix_unicode_dashes.py
+++ b/tests/acceptance/test_fix_unicode_dashes.py
@@ -36,7 +36,7 @@ foo－bar−baz
     assert (
         result.file_data
         == """
-foo-bar-baz
+foo--bar-baz
 """
     )
 
@@ -97,5 +97,41 @@ foo–bar—baz–qux—quux
         result.file_data
         == """
 foo-bar--baz-qux--quux
+"""
+    )
+
+
+def test_fix_unicode_dashes_new_characters(runner):
+    # Test the new characters added based on reviewer feedback
+    # U+2012 (figure dash), U+02D7 (modifier letter minus), U+2796 (heavy minus)
+    # U+2010 (hyphen), U+2011 (non-breaking hyphen), U+FE63 (small hyphen-minus)
+    result = runner(
+        fix_unicode_dashes_main,
+        """
+foo‒bar˗baz➖qux‐quux‑corge﹣grault
+""",
+    )
+    assert result.exit_code == 1
+    assert (
+        result.file_data
+        == """
+foo-bar-baz-qux-quux-corge-grault
+"""
+    )
+
+
+def test_fix_unicode_dashes_small_em_dash(runner):
+    # U+FE58 (SMALL EM DASH)
+    result = runner(
+        fix_unicode_dashes_main,
+        """
+foo﹘bar
+""",
+    )
+    assert result.exit_code == 1
+    assert (
+        result.file_data
+        == """
+foo--bar
 """
     )


### PR DESCRIPTION
This PR adds a new pre-commit hook that replaces Unicode dash characters with appropriate ASCII equivalents, addressing the semantic differences between different dash types.

## Changes

- Add `fix_unicode_dashes.py` implementation
- Convert em-dash (—) to ASCII double hyphen (--) for better semantic matching
- Convert en-dash (–), minus sign (−), and other dash variants to ASCII single hyphen (-)
- Follow pattern from quote fixer with separate handling for different dash types
- Add entry point in `setup.cfg`
- Register hook in `.pre-commit-hooks.yaml`
- Add comprehensive acceptance tests

## Implementation Details

The hook now properly handles the semantic difference between dash types:

### Em-dash treatment (→ `--`)

- **U+2014 EM DASH (—)**: Used for parenthetical remarks, emphasis, and breaks
- **U+FF0D FULLWIDTH HYPHEN-MINUS (－)**: Copy-paste issues, treated as em-dash per reviewer suggestion
- **U+FE58 SMALL EM DASH (﹘)**: Small variant of em-dash

### Hyphen treatment (→ `-`)

- **U+2013 EN DASH (–)**: Used for ranges, connections, and scores
- **U+2212 MINUS SIGN (−)**: Used for mathematical operations
- **U+2012 FIGURE DASH (‒)**: Typographic figure dash
- **U+02D7 MODIFIER LETTER MINUS SIGN (˗)**: Phonetic notation
- **U+2796 HEAVY MINUS SIGN (➖)**: Bold/minus sign variant
- **U+2010 HYPHEN (‐)**: Standard hyphen (different from hyphen-minus)
- **U+2011 NON-BREAKING HYPHEN (‑)**: Hyphen that prevents line breaks
- **U+FE63 SMALL HYPHEN-MINUS (﹣)**: Small variant of hyphen-minus

This follows the repository owner's suggestion to use `--` for em-dashes, as that's what several markup languages use, and includes all suggested Unicode dash variants for comprehensive coverage.

## Testing

All tests pass and the hook works as expected across multiple Python versions.

Closes #108
