### PR TITLE
add fix-arrows as a feature

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,3 +1,9 @@
+- id: fix-arrows
+  name: Fix Unicode arrow characters
+  description: 'Replace Unicode arrow characters (->, <-, =>, etc.) with ASCII equivalents'
+  entry: fix-arrows
+  language: python
+  types: [text]
 - id: fix-smartquotes
   name: Fix smartquote characters
   description: 'Replace "smartquote" characters with regular quotes'

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ fix-smartquotes FILENAME
 | **Hook**                 | **Description**                                  |
 | ------------------------ | ------------------------------------------------ |
 | `alphabetize-codeowners` | Alphabetize names in CODEOWNERS files.           |
+| `fix-arrows`             | Replace Unicode arrows with ASCII equivalents.   |
 | `fix-smartquotes`        | Replace curly quotes with ASCII quotes.          |
 | `fix-spaces`             | Normalize special space markers to ASCII spaces. |
 | `fix-unicode-dashes`     | Normalize various dash characters to ASCII.      |
@@ -134,6 +135,16 @@ You could override the space codepoints as follows:
       args: ["--separator-codepoints", "2009"]
 ```
 
+### `fix-arrows`
+
+Replace various unicode arrow characters with their ASCII equivalents.
+
+For example, the rightwards arrow (`→`) becomes `->`, the leftwards double
+arrow (`⇐`) becomes `<=`, and the long left-right arrow (`⟷`) becomes `<-->`.
+
+Only arrows which have an unambiguous ASCII representation are converted.
+Vertical and diagonal arrows (e.g. `↑`, `↓`, `↗`) are left untouched.
+
 ### `fix-unicode-dashes`
 
 Replace various unicode dash characters with `"-"` and `"--"`.
@@ -222,6 +233,8 @@ following sample config:
 - Remove support for Python 3.8 and 3.9
 - Add a `--check` flag to all fixers, which checks for changes but does not
   apply them.
+- Add `fix-arrows` fixer, which replaces Unicode arrow characters with ASCII
+  equivalents.
 
 ### 0.7.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ source = "https://github.com/sirosen/texthooks"
 
 [project.scripts]
 alphabetize-codeowners = "texthooks.alphabetize_codeowners:main"
+fix-arrows = "texthooks.fix_arrows:main"
 fix-smartquotes = "texthooks.fix_smartquotes:main"
 fix-spaces = "texthooks.fix_spaces:main"
 fix-ligatures = "texthooks.fix_ligatures:main"

--- a/src/texthooks/fix_arrows.py
+++ b/src/texthooks/fix_arrows.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""
+A fixer script which crawls text files and replaces Unicode arrow characters
+with ASCII equivalents.
+
+This converts arrows which have unambiguous ASCII representations, such as the
+rightwards arrow (U+2192) to ``->`` and the leftwards double arrow (U+21D0) to
+``<=``.
+
+Vertical and diagonal arrows (e.g. the upwards arrow, U+2191) are intentionally
+ignored, as they have no unambiguous ASCII form.
+"""
+
+import re
+import sys
+import typing as t
+
+from ._common import all_filenames, codepoint2char, parse_cli_args
+from ._recorders import DiffRecorder
+
+# map unicode codepoints to ASCII versions of those arrows
+CODEPOINT_MAP = {
+    # single-line arrows
+    "2190": "<-",  # Leftwards Arrow
+    "2192": "->",  # Rightwards Arrow
+    "2194": "<->",  # Left Right Arrow
+    "21A6": "|->",  # Rightwards Arrow From Bar
+    # double-line arrows
+    "21D0": "<=",  # Leftwards Double Arrow
+    "21D2": "=>",  # Rightwards Double Arrow
+    "21D4": "<=>",  # Left Right Double Arrow
+    # long arrows
+    "27F5": "<--",  # Long Leftwards Arrow
+    "27F6": "-->",  # Long Rightwards Arrow
+    "27F7": "<-->",  # Long Left Right Arrow
+    "27F8": "<==",  # Long Leftwards Double Arrow
+    "27F9": "==>",  # Long Rightwards Double Arrow
+    "27FA": "<==>",  # Long Left Right Double Arrow
+}
+CHAR_MAP = {  # remap in terms of chars
+    codepoint2char(k): v for k, v in CODEPOINT_MAP.items()
+}
+REPLACEMENT_PATTERN = re.compile("(" + "|".join(CHAR_MAP.keys()) + ")")
+
+
+def _re_subfunc(match: re.Match) -> str:
+    x = match.group(0)
+    return CHAR_MAP.get(x, x)
+
+
+def charwidth(c: str) -> int:
+    return len(CHAR_MAP.get(c, c))
+
+
+def replace_arrows_str(s: str) -> str:
+    return REPLACEMENT_PATTERN.sub(_re_subfunc, s)
+
+
+def do_all_replacements(
+    files: t.Iterable[str] | None, verbosity: int, check: bool
+) -> DiffRecorder:
+    """Do replacements over a set of filenames, and return a list of filenames
+    where changes were made."""
+    recorder = DiffRecorder(verbosity, check=check)
+
+    for fn in all_filenames(files):
+        recorder.run_line_fixer(replace_arrows_str, fn)
+    return recorder
+
+
+def parse_args(argv: list[str] | None) -> t.Any:
+    return parse_cli_args(__doc__, argv=argv, fixer=True)
+
+
+def main(*, argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    changes = do_all_replacements(
+        all_filenames(args.files), args.verbosity, check=args.check
+    )
+    if changes:
+        changes.print_changes(args.show_changes, args.color, charwidth=charwidth)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/acceptance/test_fix_arrows.py
+++ b/tests/acceptance/test_fix_arrows.py
@@ -1,0 +1,79 @@
+from textwrap import dedent as d
+
+from texthooks.fix_arrows import main as fix_arrows_main
+
+
+def test_fix_arrows_no_changes(runner):
+    result = runner(fix_arrows_main, "foo")
+    assert result.exit_code == 0
+    assert result.file_data == "foo"
+
+
+def test_fix_arrows_no_changes_verbose(runner):
+    result = runner(fix_arrows_main, "foo", add_args=["-v"])
+    assert result.exit_code == 0
+    assert result.file_data == "foo"
+    assert "checking file.txt...ok" in result.stdout
+
+
+def test_fix_arrows_rightwards_arrow(runner):
+    result = runner(
+        fix_arrows_main,
+        """
+        a → b
+        """,
+    )
+    assert result.exit_code == 1
+    assert result.file_data == d("""
+        a -> b
+        """)
+    assert "checking file.txt..." not in result.stdout
+
+
+def test_fix_arrows_rightwards_arrow_verbose(runner):
+    result = runner(fix_arrows_main, "a → b\n", add_args=["-v"])
+    assert result.exit_code == 1
+    assert result.file_data == "a -> b\n"
+    assert "checking file.txt...fail" in result.stdout
+
+
+def test_fix_arrows_multiple_kinds(runner):
+    result = runner(
+        fix_arrows_main,
+        """
+        ← → ↔ ⇐ ⇒ ⇔ ⟶ ⟺ ↦
+        """,
+    )
+    assert result.exit_code == 1
+    assert result.file_data == d("""
+        <- -> <-> <= => <=> --> <==> |->
+        """)
+
+
+def test_fix_arrows_check_does_not_modify(runner):
+    result = runner(fix_arrows_main, "a → b\n", add_args=["--check"])
+    assert result.exit_code == 1
+    assert result.file_data == "a → b\n"
+
+
+def test_fix_arrows_ignores_vertical_arrows(runner):
+    result = runner(fix_arrows_main, "up ↑ down ↓\n")
+    assert result.exit_code == 0
+    assert result.file_data == "up ↑ down ↓\n"
+
+
+def test_fix_arrows_showchanges_nocolor(runner):
+    result = runner(
+        fix_arrows_main,
+        "a → b → c\n",
+        add_args=["--show-changes", "--color=off"],
+    )
+    assert result.exit_code == 1
+    assert result.file_data == "a -> b -> c\n"
+    assert result.stdout == d(f"""\
+        Changes were made in these files:
+          {result.filename}
+          line 1:
+            - a → b → c
+            + a -> b -> c
+        """)


### PR DESCRIPTION
Adds `fix-arrows` as an option.

This replaces the `→` , `⟷` with the ascii equivalent. Super useful since AI add these characters almost everywhere and it never renders correctly.